### PR TITLE
overhaul layer to use new features of reactive, apt layer fixes #10

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,1 +1,76 @@
-includes: ['layer:basic', 'interface:pgsql', 'interface:http']
+includes:
+  - 'layer:basic'
+  - 'layer:apt'
+  - 'interface:pgsql'
+  - 'interface:http'
+defines:
+  install-path:
+    type: string
+    default: '/srv/django'
+    description: 'install path for django site'
+  settings-import:
+    type: string
+    default: '.settings'
+    description: 'python import path for the settings module'
+  pip-requirements:
+    type: string
+    description: 'path relative to `install-path` for a pip requirements.txt file'
+  wsgi:
+    type: string
+    default: '.wsgi:application'
+    description: 'Python import path relative to install-path for wsgi'
+  source:
+    type: object
+    params:
+      url:
+        type: string
+        description: 'vcs source (lp, github, etc) for Django site'
+  python:
+    type: string
+    default: '/usr/bin/python'
+  pip:
+    default: '/usr/bin/pip'
+    type: string
+    description: 'full path to pip binary for installation'
+  static-path:
+    default: 'static'
+    type: string
+    description: 'relative path from install-path for static content'
+  media-path:
+    default: 'static'
+    type: string
+    description: 'relative path from install-path for media content'
+options:
+  basic:
+    packages:
+      - 'build-essential'
+      - 'binutils-doc'
+      - 'autoconf'
+      - 'authbind'
+      - 'bison'
+      - 'libjpeg-dev'
+      - 'libfreetype6-dev'
+      - 'zlib1g-dev'
+      - 'libzmq3-dev'
+      - 'libgdbm-dev'
+      - 'libncurses5-dev'
+      - 'automake'
+      - 'libtool'
+      - 'libffi-dev'
+      - 'curl'
+      - 'git'
+      - 'gettext'
+      - 'flex'
+      - 'postgresql-client'
+      - 'postgresql-client-common'
+      - 'python3'
+      - 'python3-pip'
+      - 'python-dev'
+      - 'python3-dev'
+      - 'python-pip'
+      - 'libxml2-dev'
+      - 'virtualenvwrapper'
+      - 'libxslt-dev'
+      - 'git-core',
+      - 'python-git'
+      - 'libpq-dev'

--- a/lib/charms/django.py
+++ b/lib/charms/django.py
@@ -1,41 +1,4 @@
-import yaml
-import subprocess
+from warnings import warn
+from charms.layer.django import *
 
-from charmhelpers.core.unitdata import kv
-from charmhelpers.core.hookenv import status_set
-
-def config():
-    db = kv()
-    with open('django.yaml') as f:
-        django_cfg = yaml.safe_load(f.read())
-
-    for k, v in django_cfg.items():
-        db.set(k, v)
-
-    return db
-
-
-def manage(cmd):
-    dcfg = config()
-    if not isinstance(cmd, list):
-        cmd = cmd.split(' ')
-
-    exe = [python(), 'manage.py']
-    extra = []
-    if dcfg.get('config-import'):
-        extra.append('--settings=%s' % dcfg.get('config-import'))
-
-    status_set('maintenance', ' '.join(['manage.py'] + cmd))
-    call(exe + cmd + extra)
-
-def call(cmd):
-    dcfg = config()
-    subprocess.check_call(cmd, cwd=dcfg.get('source-path'))
-
-
-def pip():
-    return config().get('pip', '/usr/bin/pip')
-
-
-def python():
-    return config().get('python', '/usr/bin/python')
+warn('this module is being deprecated, use charms.layer.django instead')

--- a/lib/charms/layer/django.py
+++ b/lib/charms/layer/django.py
@@ -1,0 +1,47 @@
+import os
+import yaml
+import subprocess
+
+from charmhelpers.core.unitdata import kv
+from charmhelpers.core.hookenv import status_set
+from charms import layer
+
+def config():
+    db = kv()
+
+    if os.path.exists('django.yaml'):
+        with open('django.yaml') as f:
+            django_cfg = yaml.safe_load(f.read())
+    else:
+        django_cfg = layer.options('django')
+
+    for k, v in django_cfg.items():
+        db.set(k, v)
+
+    return db
+
+
+def manage(cmd):
+    dcfg = config()
+    if not isinstance(cmd, list):
+        cmd = cmd.split(' ')
+
+    exe = [python(), 'manage.py']
+    extra = []
+    if dcfg.get('config-import'):
+        extra.append('--settings=%s' % dcfg.get('config-import'))
+
+    status_set('maintenance', ' '.join(['manage.py'] + cmd))
+    call(exe + cmd + extra)
+
+def call(cmd):
+    dcfg = config()
+    subprocess.check_call(cmd, cwd=dcfg.get('source-path'))
+
+
+def pip():
+    return config().get('pip', '/usr/bin/pip')
+
+
+def python():
+    return config().get('python', '/usr/bin/python')

--- a/reactive/django.py
+++ b/reactive/django.py
@@ -47,7 +47,7 @@ def install():
 @when('django.ready')
 @when('website.available')
 def send_port(http):
-    http.configure(80)
+    http.configure(config('django-port'))
 
 
 @when('django.source.available')
@@ -130,6 +130,9 @@ def source_install(dcfg):
     status_set('maintenance', 'installing %s repo' % source['url'])
     if not os.path.exists(dcfg.get('install-path')):
         os.makedirs(dcfg.get('install-path'))
+
+    if 'url' not in source:
+        return
 
     source_path = install_remote(source['url'],
                                  dest=dcfg.get('install-path'))

--- a/reactive/django.py
+++ b/reactive/django.py
@@ -20,8 +20,8 @@ from charmhelpers.fetch import (
     apt_install,
     install_remote,
 )
+from charms.layer import django
 
-from charms import django
 from charms.reactive import (
     hook,
     when,

--- a/reactive/django.py
+++ b/reactive/django.py
@@ -115,7 +115,6 @@ def start():
         service_start('circus')
 
     set_state('circus.running')
-    remove_state('django.restart')
 
 
 @when('django.ready')
@@ -123,6 +122,7 @@ def start():
 def restart():
     remove_state('circus.running')
     start()
+    remove_state('django.restart')
 
 
 def source_install(dcfg):


### PR DESCRIPTION
The largest change here is the deprecation of `charms.django` for the better, `charms.layer.django`. The deprecation process means those importing charms.django should continue to work until I get tired of having it.

Furthermore, this deprecates `django.yaml` as the means to supply configuration for layer options instead. To upgrade, simple copy your django.yaml contents to layer.yaml under the following keys:

``` yaml
options:
  django:
    YOUR-DJANGO-YAML
```

with the exception of the `apt-packages` key which should instead be placed as such:

``` yaml
options:
  django:
    YOUR-DJANGO-YAML
  basic:
    packages:
      - list
      - of packages
```
